### PR TITLE
Allow createSignature to accept a commit payload string

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ This method returns a `Promise` containing a `string` which is the PGP signature
 
 Use this method with the same payload that you would send to the GitHub API `POST /repos/:owner/:repo/git/commits` endpoint.
 
-To use this method, the `author` argument is **mandatory**, as opposed to the optional argument for the API. This is necessary since we need to generate the commit message string with the same `date` argument as GitHub will do to verify the signature.
+It accepts either an already git-computed commit payload (see [GitHub's example](https://developer.github.com/v3/git/commits/#example-input)) which is the git content for a commit object, or a `CommitPayload` object.
+
+When using a `CommitPayload` object, the `author` argument is **mandatory**, as opposed to the optional argument for the API. This is necessary since we need to generate the commit message string with the same `date` argument as GitHub will do to verify the signature.
 
 The `committer` argument is still optional and will default to the `author` value if omitted.
 
@@ -90,7 +92,7 @@ In the following example, the commit will be signed for `Dohn Joe`. Hence, `priv
 ###### Usage
 
 ```js
-import { createSignature } from 'github-api-signature';
+import { createSignature, commitToString } from 'github-api-signature';
 
 const privateKey: string = `-----BEGIN PGP PRIVATE KEY BLOCK-----
 
@@ -117,6 +119,7 @@ const commit: CommitPayload = {
     }
 };
 
+// Using a CommitPayload object
 createSignature(commit, privateKey, passphrase)
 .then((signature: string) => {
     // signature = `-----BEGIN PGP SIGNATURE-----
@@ -133,13 +136,21 @@ createSignature(commit, privateKey, passphrase)
     // https://developer.github.com/v3/git/commits/#create-a-commit
     // POST /repos/:owner/:repo/git/commits
 });
+
+// Using a git-computed commit payload string
+// commitToString returns the same format as "git cat-file -p <commit-sha>"
+const commitStr = commitToString(commit);
+createSignature(commitStr, privateKey, passphrase)
+.then((signature: string) => {
+    // ...
+});
 ```
 
 ###### Type definitions
 
 ```js
 async function createSignature(
-    commit: CommitPayload,
+    commit: CommitPayload | string,
     privateKey: string,
     passphrase: string
 ): Promise<string> {}

--- a/src/createSignature.ts
+++ b/src/createSignature.ts
@@ -8,7 +8,9 @@ import { commitToString, normalizeString } from './utils';
  * https://developer.github.com/v3/git/commits/#create-a-commit
  */
 export async function createSignature(
-    commit: CommitPayload,
+    // Accepts either a commit defails object
+    // or the already computed commit string
+    commit: CommitPayload | string,
     privateKey: string,
     passphrase: string
 ): Promise<string> {
@@ -24,8 +26,12 @@ export async function createSignature(
         throw new Error('Failed to decrypt private key using given passphrase');
     }
 
+    // Convert commit object to a string if needed
+    const commitString =
+        typeof commit === 'string' ? commit : commitToString(commit);
+
     const { signature } = await openpgp.sign({
-        message: openpgp.message.fromText(commitToString(commit)),
+        message: openpgp.message.fromText(commitString),
         privateKeys: [privateKeyObj],
         detached: true
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { createSignature } from './createSignature';
 export { generateKeyPair } from './generateKeyPair';
+export { commitToString } from './utils';

--- a/src/tests/createSignature.ts
+++ b/src/tests/createSignature.ts
@@ -20,7 +20,7 @@ test('generate a valid PGP signature for the provided payload', async t => {
         numBits
     );
 
-    // Generate a signature
+    // Generate a signature from a given CommitPayload object
     const commit: CommitPayload = {
         message: 'Commit message',
         tree: 'tree-sha',
@@ -32,6 +32,45 @@ test('generate a valid PGP signature for the provided payload', async t => {
     };
 
     const signature = await createSignature(commit, privateKey, passphrase);
+    t.true(signature.startsWith('-----BEGIN PGP SIGNATURE-----'));
+
+    // Verify signature
+    const verified = await openpgp.verify({
+        message: openpgp.message.fromText(commitToString(commit)),
+        signature: await openpgp.signature.readArmored(signature),
+        publicKeys: (await openpgp.key.readArmored(publicKey)).keys
+    });
+    t.true(verified.signatures[0].valid);
+});
+
+test('generate a valid PGP signature for the provided commit string', async t => {
+    // Generate a key pair
+    const passphrase = 'my secret phrase';
+    const numBits = 512;
+    const user: UserInformations = {
+        name: 'John Doe',
+        email: 'ghost@github.com'
+    };
+
+    const { publicKey, privateKey } = await generateKeyPair(
+        user,
+        passphrase,
+        numBits
+    );
+
+    // Generate a signature from an already git-computed commit string
+    const commit: CommitPayload = {
+        message: 'Commit message',
+        tree: 'tree-sha',
+        parents: ['parent-sha'],
+        author: {
+            ...user,
+            date: new Date().toISOString()
+        }
+    };
+
+    const commitStr = commitToString(commit);
+    const signature = await createSignature(commitStr, privateKey, passphrase);
     t.true(signature.startsWith('-----BEGIN PGP SIGNATURE-----'));
 
     // Verify signature


### PR DESCRIPTION
This allows to pass `createSignature` the value of `git cat-file -p <commit-sha>`.
Useful for instance to use this module to sign with `isomorphic-git`.